### PR TITLE
ci: stop calling setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,11 @@ setup(
     name="uaaextras",
     version="0.0.1",
     description="A simple UI for UAA /invite_users endpoint and password resets",
-    url="https://github.com/18F/cg-uaa-extras",
+    url="https://github.com/cloud-gov/cg-uaa-extras",
     author="Chris Nelson",
     author_email="cnelson@cnelson.org",
     license="Public Domain",
     packages=find_packages(exclude=["integration_tests*", "test"]),
     install_requires=[
     ],
-    test_suite="uaaextras.tests",
-    tests_require=[],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
   -rrequirements.txt
   -rrequirements-dev.txt
 commands =
-  python setup.py test
+  python -m unittest discover uaaextras.tests
 
 [testenv:flake8]
 basepython = python3.10


### PR DESCRIPTION
## Changes proposed in this pull request:
- setuptools no longer supports `setup.py test` so we need to call `python -m unittest discover` instead
- fix a reference to the 18f github org 


## security considerations
This arguably improves security very slightly, since running things through setup.py makes it easier for arbitrary code execution, but the security implication of this PR is negligible.