### PR TITLE
ci: move unit tests to their own job

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -22,6 +22,7 @@ jobs:
       cg-uaa-extras-app: uaa-extras-integrated
     file: cg-uaa-extras-app/ci/test.yml
 
+
 - name: deploy-development
   plan:
   - get: general-task
@@ -30,6 +31,9 @@ jobs:
   - get: cg-uaa-extras-app
     passed: [unittests]
     trigger: true
+  - task: integrate-repos
+    image: general-task
+    file: cg-uaa-extras-app/ci/integrate.yml
   - put: create-db
     resource: cf-cli-dev
     params: &db-params
@@ -102,6 +106,9 @@ jobs:
   - get: cg-uaa-extras-app
     passed: [deploy-development]
     trigger: true
+  - task: integrate-repos
+    image: general-task
+    file: cg-uaa-extras-app/ci/integrate.yml
   - put: create-db
     resource: cf-cli-staging
     params:
@@ -168,6 +175,9 @@ jobs:
   - get: cg-uaa-extras-app
     passed: [deploy-staging]
     trigger: true
+  - task: integrate-repos
+    image: general-task
+    file: cg-uaa-extras-app/ci/integrate.yml
   - put: create-db
     resource: cf-cli-production
     params:
@@ -211,7 +221,6 @@ jobs:
       channel: '#cg-platform-news'
       username: ((slack-username))
       icon_url: ((slack-icon-url))
-
 
 resources:
 - name: dotgov-domain-data

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -8,11 +8,8 @@ jobs:
   - set_pipeline: self
     file: cg-uaa-extras-app/ci/pipeline.yml
 
-- name: deploy-development
+- name: unittests
   plan:
-  - get: general-task
-  - get: dotgov-domain-data
-    trigger: true
   - get: cg-uaa-extras-app
     passed: [set-self]
     trigger: true
@@ -24,6 +21,15 @@ jobs:
     input_mapping:
       cg-uaa-extras-app: uaa-extras-integrated
     file: cg-uaa-extras-app/ci/test.yml
+
+- name: deploy-development
+  plan:
+  - get: general-task
+  - get: dotgov-domain-data
+    trigger: true
+  - get: cg-uaa-extras-app
+    passed: [unittests]
+    trigger: true
   - put: create-db
     resource: cf-cli-dev
     params: &db-params
@@ -96,9 +102,6 @@ jobs:
   - get: cg-uaa-extras-app
     passed: [deploy-development]
     trigger: true
-  - task: integrate-repos
-    image: general-task
-    file: cg-uaa-extras-app/ci/integrate.yml
   - put: create-db
     resource: cf-cli-staging
     params:
@@ -165,9 +168,6 @@ jobs:
   - get: cg-uaa-extras-app
     passed: [deploy-staging]
     trigger: true
-  - task: integrate-repos
-    image: general-task
-    file: cg-uaa-extras-app/ci/integrate.yml
   - put: create-db
     resource: cf-cli-production
     params:


### PR DESCRIPTION


## Changes proposed in this pull request:
- move unit tests to their own job for clarity
- don't rerun integrate repos every job (I am not 100% sure this will work)


## security considerations
None - this is just reorganizing tests